### PR TITLE
WipeCharacterTable/WipeGuildTable: skip non-table inputs

### DIFF
--- a/DataStore/DataStore.lua
+++ b/DataStore/DataStore.lua
@@ -396,7 +396,7 @@ function addon:DeleteRealm(realm, account)
 end
 
 local function WipeCharacterTable(t)
-	if not t then return end
+	if type(t) ~= "table" then return end
 
 	for key, v in pairs(t) do	-- key is the character key
 		if key ~= addon.ThisCharKey then	-- only delete an entry if it is not the current character
@@ -406,7 +406,7 @@ local function WipeCharacterTable(t)
 end
 
 local function WipeGuildTable(t)
-	if not t then return end
+	if type(t) ~= "table" then return end
 
 	for key, v in pairs(t) do	-- key is the guild key
 		t[key] = nil


### PR DESCRIPTION
Clicking *Wipe Database* in the Altoholic Summary crashes with `bad argument #1 to 'pairs' (table expected, got function)` from `DataStore.lua:382`.

`ClearAllData` iterates the registered modules and passes `moduleDB.Characters` / `.Guilds` into the wipe helpers. For some modules these resolve to a function (via the DataStore method metatable), so the existing `if not t then return end` guard passes through and `pairs(t)` then errors.

Using a `type(t) ~= "table"` check instead lets non-table values fall through silently, which matches the original intent for "no character table on this module."

Fixes Thaoky/Altoholic_Retail#33.